### PR TITLE
Remove `keep_prefix` default behavior... actually remove the feature entirely.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
 
 jobs:
-  pep8-linter:
+  python-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Unit Tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           exit 1
         fi
         # Test whitelist.
+        echo -e "\n\nTesting botoprune.whitelist - keeping s3 and ec2"
         python -m botoprune.whitelist s3 ec2
         BOTO_DATA_COUNT=$(ls -l venv/lib/python3.10/site-packages/botocore/data/ | wc -l)
         if [ $BOTO_DATA_COUNT -gt 15 ]; then
@@ -48,6 +49,7 @@ jobs:
           exit 1
         fi
         # Test remove.
+        echo -e "\n\nTesting botoprune.remove - removing s3"
         python -m botoprune.remove s3
         if [ -d venv/lib/python3.10/site-packages/botocore/data/s3 ]; then
           echo "s3 data was not removed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,9 @@ jobs:
           exit 1
         fi
         # Test whitelist.
-        echo -e "\n\nTesting botoprune.whitelist - keeping s3 and ec2"
+        echo "."
+        echo "."
+        echo  "Testing botoprune.whitelist - keeping s3 and ec2"
         python -m botoprune.whitelist s3 ec2
         BOTO_DATA_COUNT=$(ls -l venv/lib/python3.10/site-packages/botocore/data/ | wc -l)
         if [ $BOTO_DATA_COUNT -gt 15 ]; then
@@ -49,7 +51,9 @@ jobs:
           exit 1
         fi
         # Test remove.
-        echo -e "\n\nTesting botoprune.remove - removing s3"
+        echo "."
+        echo "."
+        echo "Testing botoprune.remove - removing s3"
         python -m botoprune.remove s3
         if [ -d venv/lib/python3.10/site-packages/botocore/data/s3 ]; then
           echo "s3 data was not removed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Python Tests
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  pep8-linter:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+
+    - name: Unit Tests
+      run: |
+        python3 -m venv venv
+        source venv/bin/activate
+        python -m pip install .[test]
+        pytest
+        # Run destructive tests
+        pytest -m destructive
+        # Clean up
+        deactivate
+        rm -rf venv
+    
+    - name: Module Test
+      run: |
+        python3 -m venv venv
+        source venv/bin/activate
+        python -m pip install boto3
+        python -m pip install .
+        # Validate installation.
+        BOTO_DATA_COUNT=$(ls -l venv/lib/python3.10/site-packages/botocore/data/ | wc -l)
+        if [ $BOTO_DATA_COUNT -lt 100 ]; then
+          echo "Boto data directory has less than 100 files, somthing is wrong with the installation"
+          exit 1
+        fi
+        # Test whitelist.
+        python -m botoprune.whitelist s3 ec2
+        BOTO_DATA_COUNT=$(ls -l venv/lib/python3.10/site-packages/botocore/data/ | wc -l)
+        if [ $BOTO_DATA_COUNT -gt 15 ]; then
+          echo "Boto data was not pruned"
+          exit 1
+        fi
+        # Test remove.
+        python -m botoprune.remove s3
+        if [ -d venv/lib/python3.10/site-packages/botocore/data/s3 ]; then
+          echo "s3 data was not removed"
+          exit 1
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
         if [ $BOTO_DATA_COUNT -gt 15 ]; then
           echo "Boto data was not pruned"
           exit 1
+        else
+          echo "Result validated; most content of 'botocore/data' was removed"
         fi
         # Test remove.
         echo "."
@@ -58,4 +60,8 @@ jobs:
         if [ -d venv/lib/python3.10/site-packages/botocore/data/s3 ]; then
           echo "s3 data was not removed"
           exit 1
+        else
+          echo "Result validated; s3 data was removed"
         fi
+        # Clean up
+        deactivate

--- a/botoprune/_implementation.py
+++ b/botoprune/_implementation.py
@@ -89,14 +89,11 @@ def remove_services(remove_targets: list[str], dry_run: bool):
     return kept_services, removed_services
 
 
-def whitelist_prune_services(whitelist_targets: list[str], keep_prefix: bool, dry_run: bool):
+def whitelist_prune_services(whitelist_targets: list[str], dry_run: bool):
     """Prune botocore data to only include the specified services.
 
     Args:
         whitelist_targets: List of services to keep.
-        keep_prefix: If set to true, then any whitelisted service will also
-                     whitelist services with the same prefix. For example s3
-                     would transitively whitelist s3control, s3outposts, etc.
         dry_run: If set to true, then do not actually delete any services, just
                  print what would be deleted.
 
@@ -107,26 +104,8 @@ def whitelist_prune_services(whitelist_targets: list[str], keep_prefix: bool, dr
     """
     data_dir, botocore_services = list_installed_botocore_services()
 
-    # Create dict to find prefix whitelisted services. This takes advantage of
-    # the alphabetical ordering of the services to create a dictionary of
-    # services with the same prefix.
-    if keep_prefix:
-        prefix_whitelist = defaultdict(list)
-        for i in range(len(botocore_services)):
-            service_prefix = botocore_services[i]
-            j = i + 1
-            while j < len(botocore_services) and botocore_services[j].startswith(service_prefix):
-                prefix_whitelist[service_prefix].append(botocore_services[j])
-                j += 1
-    else:
-        prefix_whitelist = {}
-
     # Create set of services to keep including transitive whitelist members.
-    full_whitelist = list(whitelist_targets)
-    for service in whitelist_targets:
-        if service in prefix_whitelist:
-            full_whitelist.extend(prefix_whitelist[service])
-    full_whitelist = set(full_whitelist)
+    full_whitelist = set(whitelist_targets)
 
     # Set of services that were whitelisted but not found in botocore.
     whitelist_failures = [s for s in full_whitelist if s not in botocore_services]

--- a/botoprune/_implementation.py
+++ b/botoprune/_implementation.py
@@ -15,7 +15,6 @@
 import botocore
 import os
 import shutil
-from collections import defaultdict
 
 try:
     import botocore.data as botocore_data

--- a/botoprune/whitelist.py
+++ b/botoprune/whitelist.py
@@ -29,12 +29,6 @@ if __name__ == '__main__':
         help='List of AWS services to keep in botocore data.',
     )
     parser.add_argument(
-        '--keep-prefix',
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help='Keep services with the same prefix (ex. s3 would keep s3control, s3outposts, etc.)',
-    )
-    parser.add_argument(
         '--dry-run',
         default=False,
         action=argparse.BooleanOptionalAction,
@@ -46,7 +40,6 @@ if __name__ == '__main__':
     try:
         kept_services, pruned_services = whitelist_prune_services(
             whitelist_targets=args.keep_services,
-            keep_prefix=args.keep_prefix,
             dry_run=args.dry_run,
         )
     except BotoPruneError as e:

--- a/test/botoprune_test.py
+++ b/test/botoprune_test.py
@@ -30,23 +30,12 @@ class TestBotoprune(unittest.TestCase):
         self.assertNotIn('s3', kept)
         self.assertNotIn('s3control', kept)
         self.assertNotIn('ec2', kept)
-
-    def test_whitelist_prune_services_prefix(self):
-        whitelist = ['s3', 's3control', 'ec2']
-        whitelist_check = [t for t in whitelist] + ['ec2-instance-connect', 's3outposts', 's3tables', 's3vectors']
-        kept, removed = implementation.whitelist_prune_services(
-            whitelist_targets=whitelist,
-            keep_prefix=True,
-            dry_run=True,
-        )
-        self.assertCountEqual(kept, whitelist_check)
     
-    def test_whitelist_prune_services_no_prefix(self):
+    def test_whitelist_prune_services(self):
         whitelist = ['s3', 's3control', 'ec2']
         whitelist_check = [t for t in whitelist]
         kept, removed = implementation.whitelist_prune_services(
             whitelist_targets=whitelist,
-            keep_prefix=False,
             dry_run=True,
         )
         self.assertCountEqual(kept, whitelist_check)
@@ -59,12 +48,11 @@ class TestBotoprune(unittest.TestCase):
         service_count = len(services)
         self.assertTrue(service_count > 100)
 
-        # Prune services using a whitelist without prefix expansion.
+        # Prune services using a whitelist.
         whitelist = ['s3', 's3control', 'ec2']
         whitelist_check = [t for t in whitelist]
         kept, removed = implementation.whitelist_prune_services(
             whitelist_targets=whitelist,
-            keep_prefix=False,
             dry_run=False,
         )
         self.assertCountEqual(kept, whitelist_check)


### PR DESCRIPTION
This feature was not good at all. Felt like it was a good idea. It was complicated and I ended up disabling it. Very bad as a default, bad generally as an inclusion. If a user wants to keep services just specify them all; this is for applicaiton docker builds anyways and really should be tested.

Also this PR adds automated tests because I hadn't touched this in a few days and already forgot how to run the destructive tests.